### PR TITLE
Automatically find the name of the core bin file, instead of hardcoding

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -35,6 +35,8 @@ class App
 
     protected Container $container;
 
+    public readonly string $me;
+
     /**
      * @param  array<string, mixed>  $config
      *
@@ -49,6 +51,8 @@ class App
 
         $this->bindPaths($appRoot);
         $this->boot($config, $signature);
+
+        $this->me = $this->findBinFileName();
     }
 
     /**
@@ -311,5 +315,13 @@ class App
     public function hasService(string $serviceName): bool
     {
         return $this->container->has($serviceName);
+    }
+
+    protected function findBinFileName(): string
+    {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        // Index 0 is current method, index 1 is the instantiation
+        return basename($backtrace[1]['file'] ?? 'minicli');
     }
 }


### PR DESCRIPTION
## The Annoyance

Every time I create a new minicli app, I need to edit every mention of `minicli` to whatever the binary is.

If I want to rename the bin file, I have to edit every single mention of it in the app.

## The Solution

1. Add a `public readonly string $me` to `App` so now you can call `$app->me` to get the filename.
2. Add a `protected function findBinFileName(): string` that will automagically find the filename.
3. Call this from within the `App::__construct()`.

This way, the end-developer can easily do things like `echo "{$app->me} commad";`. You can't embed method calls into strings like that.

And the developer will never need to automate anything.